### PR TITLE
feat: Added get_mean_ecliptic_longitude_of_the_ascending_node to celerity/moon module.

### DIFF
--- a/src/celerity/moon.py
+++ b/src/celerity/moon.py
@@ -1,0 +1,31 @@
+import math
+from datetime import datetime
+
+from .epoch import get_number_of_fractional_days_since_j2000
+from .sun import get_mean_anomaly
+
+
+def get_mean_ecliptic_longitude_of_the_ascending_node(
+    date: datetime, longitude: float
+) -> float:
+    """
+    The mean lunar ecliptic longitude of the ascending node is the angle where
+    the Moon's orbit crosses the ecliptic
+
+    :param date: The datetime object to convert.
+    :return: The mean lunar ecliptic longitude of the ascending node in degrees
+    """
+    # Get the number of days since the standard epoch J2000:
+    d = get_number_of_fractional_days_since_j2000(date)
+
+    # Get the Moon's ecliptic longitude of the ascending node at the current epoch relative to J2000:
+    Ω = (125.044522 - (0.0529539 * d)) % 360
+
+    # Correct for negative angles
+    if Ω < 0:
+        Ω += 360
+
+    # Correct for the Sun's mean anomaly:
+    M = get_mean_anomaly(date, longitude)
+
+    return Ω - 0.16 * math.sin(math.radians(M))

--- a/tests/test_moon.py
+++ b/tests/test_moon.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+
+from src.celerity.common import EquatorialCoordinate, GeographicCoordinate
+from src.celerity.moon import get_mean_ecliptic_longitude_of_the_ascending_node
+
+# For testing we need to specify a date because most calculations are
+# differential w.r.t a time component. We set it to the author's birthday:
+date = datetime(2021, 5, 14, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+# For testing, we will fix the latitude to be Manua Kea, Hawaii, US
+latitude: float = 19.820611
+
+# For testing, we will fix the longitude to be Manua Kea, Hawaii, US
+longitude: float = -155.468094
+
+betelgeuse: EquatorialCoordinate = {"ra": 88.7929583, "dec": 7.4070639}
+
+observer: GeographicCoordinate = {"lat": latitude, "lon": longitude}
+
+
+def test_get_mean_ecliptic_longitude_of_the_ascending_node():
+    Ω = get_mean_ecliptic_longitude_of_the_ascending_node(date, longitude)
+    assert Ω == 71.69457220767262


### PR DESCRIPTION
feat: Added get_mean_ecliptic_longitude_of_the_ascending_node to celerity/moon module.