### PR TITLE
fix: amend get_greenwhich_sidereal_time() to correctly round microseconds in @observerly/celerity.

### DIFF
--- a/src/celerity/temporal.py
+++ b/src/celerity/temporal.py
@@ -75,7 +75,12 @@ def get_greenwhich_sidereal_time(date: datetime) -> float:
         T_0 += 24
 
     # Convert the UTC time to a decimal fraction of hours:
-    UTC = (date.microsecond / 1e6) + date.second / 60 + date.minute / 60 + date.hour
+    UTC = (
+        (date.microsecond / 3.6e9)
+        + (date.second / 3600)
+        + (date.minute / 60)
+        + date.hour
+    )
 
     A = UTC * 1.002737909
 


### PR DESCRIPTION
fix: amend get_greenwhich_sidereal_time() to correctly round microseconds in @observerly/celerity.