### PR TITLE
fix: amend get_julian_date epoch timezone conversion in celerity module

### DIFF
--- a/src/celerity/temporal.py
+++ b/src/celerity/temporal.py
@@ -28,7 +28,7 @@ def get_julian_date(date: datetime) -> float:
         int(
             (
                 date.astimezone(tz=timezone.utc)
-                - datetime(1970, 1, 1).astimezone(tz=timezone.utc)
+                - datetime(1970, 1, 1, tzinfo=timezone.utc)
             ).total_seconds()
             * 1000
         )


### PR DESCRIPTION
fix: amend get_julian_date epoch timezone conversion in celerity module