### PR TITLE
style: amend to explicit HorizontalCoordinate return in get_correction_to_horizontal_for_refraction in celerity module

### DIFF
--- a/src/celerity/refraction.py
+++ b/src/celerity/refraction.py
@@ -42,10 +42,12 @@ def get_correction_to_horizontal_for_refraction(
         * (283.15 / T)
     )
 
-    return {
-        "alt": target["alt"] + R,
-        "az": target["az"],
-    }
+    return HorizontalCoordinate(
+        {
+            "az": target["az"],
+            "alt": target["alt"] + R,
+        }
+    )
 
 
 # **************************************************************************************


### PR DESCRIPTION
style: amend to explicit HorizontalCoordinate return in get_correction_to_horizontal_for_refraction in celerity module